### PR TITLE
fix: Message for Installing YouTube Music Genius Lyrics

### DIFF
--- a/YoutubeGeniusLyrics.user.js
+++ b/YoutubeGeniusLyrics.user.js
@@ -2346,7 +2346,7 @@ function newAppHint (status) {
     const h2 = container.appendChild(document.createElement('h2'))
     h2.textContent = '⚠️ Youtube Genius Lyrics 🆕'
     const p = container.appendChild(document.createElement('p'))
-    p.textContent = '▶️ The "Youtube Genius Lyrics" UserScript is only applied on youtube.com. To view Genius lyrics on m.youtube.com, please install the separate UserScript, "Youtube Music Genius Lyrics".'
+    p.textContent = '▶️ The "Youtube Genius Lyrics" UserScript is only applied on youtube.com. To view Genius lyrics on music.youtube.com, please install the separate UserScript, "Youtube Music Genius Lyrics".'
     p.appendChild(document.createElement('br'))
     p.appendChild(document.createElement('br'))
 

--- a/YoutubeGeniusLyrics.user.js
+++ b/YoutubeGeniusLyrics.user.js
@@ -2346,7 +2346,7 @@ function newAppHint (status) {
     const h2 = container.appendChild(document.createElement('h2'))
     h2.textContent = '⚠️ Youtube Genius Lyrics 🆕'
     const p = container.appendChild(document.createElement('p'))
-    p.textContent = '▶️ If you would like to see lyrics here as well, you can now install a new userscript specifically for music.youtube.com:'
+    p.textContent = '▶️ The "Youtube Genius Lyrics" UserScript is only applied on youtube.com. To view Genius lyrics on m.youtube.com, please install the separate UserScript, "Youtube Music Genius Lyrics".'
     p.appendChild(document.createElement('br'))
     p.appendChild(document.createElement('br'))
 


### PR DESCRIPTION
<img width="1462" alt="Screen Shot 2023-09-28 at 21 03 51" src="https://github.com/cvzi/Youtube-Music-Genius-Lyrics-userscript/assets/44498510/2384af0b-9374-474d-8400-5b380ac67425">

This is to let you if they want to show genius lyrics they can install another script called XXXXXXX.


However, the message is a bit unclear. Users do not know why this is show.
`▶️ If you would like to see lyrics here as well, you can now install a new userscript specifically for music.youtube.com:`


I have asked ChatGPT to correct it, it gives the following:
`▶️ The "Youtube Genius Lyrics" UserScript is only applied on youtube.com. To view Genius lyrics on music.youtube.com, please install the separate UserScript, "Youtube Music Genius Lyrics".`


Besides, I noticed that openuserjs's links are placed in the message. Should they been changed to the script hosted on either GreasyFork or GitHub?